### PR TITLE
changed to enable testing for all access modifier.

### DIFF
--- a/src/main/java/wunit/testclass/TestClass.java
+++ b/src/main/java/wunit/testclass/TestClass.java
@@ -19,6 +19,7 @@ public class TestClass {
     public static TestClass from(Class<?> testClass) {
         List<TestCase> testCases = Arrays.stream(testClass.getDeclaredMethods())
                 .filter(method -> method.isAnnotationPresent(Test.class))
+                .map(method -> {method.setAccessible(true); return method;})
                 .map(method -> new TestCase(testClass.getSimpleName(), createObjectByTypeToken(testClass), method))
                 .collect(Collectors.toList());
         return new TestClass(testCases);
@@ -27,7 +28,7 @@ public class TestClass {
     private static Object createObjectByTypeToken(Class<?> testClass) {
         try {
             Constructor<?> declaredConstructor = testClass.getDeclaredConstructor();
-            return declaredConstructor.newInstance(null);
+            return declaredConstructor.newInstance();
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new IllegalStateException("Cannot generate test environment.");
         }

--- a/src/test/java/wunit/testclass/VerificationResultTest.java
+++ b/src/test/java/wunit/testclass/VerificationResultTest.java
@@ -28,6 +28,6 @@ class VerificationResultTest {
         String formattedMessage = testLogs.get(0).getFormattedMessage();
 
         assertThat(testLogs).hasSize(1);
-        assertThat(formattedMessage).isEqualTo("Total : 12, Passed : 5, Failed : 5, Error : 2");
+        assertThat(formattedMessage).isEqualTo("Total : 12, Passed : 5, Failed : 6, Error : 1");
     }
 }


### PR DESCRIPTION
실제 xunit에서는 접근제어자와 관계 없이 테스트가 가능합니다.
따라서 테스트 코드의 결과값을 변경하고, 접근제어자에 관계 없이 테스트가 가능하도록 변경했습니다.

https://github.com/xlffm3/WUnit/pull/4/files#diff-1a774e93d31ae9dce6c3ebfaabe60b2feb620ca4d56a7bab10a677265ccc0e86R22

위 부분에서 peek을 사용하면 더 깔끔해지는데, peek은 디버깅에만 사용한다고 알고 있어서 map을 썻습니다. 더 좋은 생각이 있나요?